### PR TITLE
refactor: Melhora iteração sobre possíveis filtros da url querystring

### DIFF
--- a/app/Http/Controllers/AddressController.php
+++ b/app/Http/Controllers/AddressController.php
@@ -18,17 +18,15 @@ class AddressController extends Controller
         $user = Auth::user();
         $query = $user->addresses();
 
-        if ($request->has('country')) {
-            $query->where('country', $request->country);
+        $filters = ['country', 'city', 'state'];
+
+        // Iterar sobre os filtros e aplicar à query
+        foreach ($filters as $filter) {
+            if ($request->has($filter)) {
+                $query->where($filter, $request->input($filter));
+            }
         }
 
-        if ($request->has('city')) {
-            $query->where('city', $request->city);
-        }
-        if ($request->has('state')) {
-            $query->where('state', $request->state);
-        }
-        
         $addresses = $query->get();
         return response()->json($addresses);
     }


### PR DESCRIPTION
Pull Request aberto para:

- Refatorar trecho de código aplicado no `AddressControler.php` onde agora uma única declaração `if` itera sobre os filtros `country`, `city` ou `state` que possam estar presentes na url querystring, substituindo por um código mais limpo a antiga versão onde continham 3 declarações `if` separadas.