### PR TITLE
refactor: Aplica novo método de teste para que dados persistam no banco e transações sejam revertidas

### DIFF
--- a/tests/Feature/AddressControllerTest.php
+++ b/tests/Feature/AddressControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Hash;
 use PHPOpenSourceSaver\JWTAuth\Facades\JWTAuth;
@@ -11,7 +11,13 @@ use App\Models\Address;
 
 class AddressControllerTest extends TestCase
 {
-    use RefreshDatabase;
+    /**
+     * O Laravel cria o teste usando o trait RefreshDatabase.
+     * Porém a cada execução das suites de teste, esse trait apaga e recria o banco de dados todo do zero.
+     * Aqui então optei por usar o trait DatabaseTransactions para envolver cada teste em uma transação de banco de dados.
+     * As transações são revertidas ao final de cada teste, garantindo que nenhuma alteração seja persistida.
+     */ 
+    use DatabaseTransactions;
 
     protected function setUp(): void
     {

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 use Illuminate\Support\Facades\Hash;
 use PHPOpenSourceSaver\JWTAuth\Facades\JWTAuth;
@@ -10,7 +10,13 @@ use App\Models\User;
 
 class UserControllerTest extends TestCase
 {
-    use RefreshDatabase;
+    /**
+     * O Laravel cria o teste usando o trait RefreshDatabase.
+     * Porém a cada execução das suites de teste, esse trait apaga e recria o banco de dados todo do zero.
+     * Aqui então optei por usar o trait DatabaseTransactions para envolver cada teste em uma transação de banco de dados.
+     * As transações são revertidas ao final de cada teste, garantindo que nenhuma alteração seja persistida.
+     */
+    use DatabaseTransactions;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
Pull Request aberto para:

- Refatorar trecho de código aplicado no `AddressControlerTest.php` e `UserControlerTest.php` . Por padrão o Laravel cria seus testes utilizando o trait RefreshDatabase. Porém a cada execução das suites de teste, esse trait apaga e recria o banco de dados todo do zero. Adotou-se então o trait DatabaseTransactions para envolver cada teste em uma transação de banco de dados. As transações são revertidas ao final dos testes, garantindo que nenhuma alteração seja persistida.